### PR TITLE
Adds yaml files for easy kubernetes install.

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+__pycache__
+venv

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8-slim
+
+ADD requirements.txt /src/
+WORKDIR /src
+
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+CMD [ "python3", "main.py" ]

--- a/config/backend.yaml
+++ b/config/backend.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: farm-intro-backend
+  labels:
+    app: farm-intro-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: farm-intro-backend
+
+  template:
+    metadata:
+      labels:
+        app: farm-intro-backend
+    spec:
+      containers:
+      - name: farm-intro
+        command:
+        - python3
+        - main.py
+        env:
+        - name: DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: mdb-admin-my-user
+              key: connectionString.standard
+        - name: DB_NAME
+          value: 'admin'
+        image: quay.io/mongodb/farm-intro-backend:0.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: farm-intro-backend
+  name: farm-intro-backend
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: farm-intro-backend
+  sessionAffinity: None
+  type: ClusterIP

--- a/config/frontend.yaml
+++ b/config/frontend.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: farm-intro-frontend
+  labels:
+    app: farm-intro-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: farm-intro-frontend
+
+  template:
+    metadata:
+      labels:
+        app: farm-intro-frontend
+    spec:
+      containers:
+      - name: farm-intro-frontend
+        command:
+        - npm
+        - start
+        image: quay.io/mongodb/farm-intro-frontend:0.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:16
+
+COPY . .
+
+RUN npm install
+CMD [ "npm", "start" ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,5 +36,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8000"
+  "proxy": "http://farm-intro-backend:8000"
 }


### PR DESCRIPTION
# Summary

With this change the FARM-Intro sample application can be installed easily in Kubernetes with:

    kubectl apply -f config/

It will connect to a MongoDB database configured from a Secret with name `mdb-admin-my-user`. This Secret should contain an entry with name `connectionString.standard`. This is the standard that the [Atlas Operator](https://github.com/mongodb/mongodb-atlas-kubernetes) and [Community Operator](https://github.com/mongodb/mongodb-kubernetes-operator) generate after deploying an Atlas or MongoDB database into your Kubernetes cluster.

Eventually we (Kube team) would like to build a _Sample Application_ that can be installed with Helm[1] on Kubernetes clusters, for our customers testing our Atlas, Community and Enterprise Operators. I've been trying to find an appropriate app for it and I think this one meets the requirements.

## TODO

- [ ] Be able to pass `"proxy"` as an environmental variable. Currently I just hardcoded it to the Service exposed by the _backend_.



- [1] Helm is like a package manager for Kubernetes clusters.